### PR TITLE
Added set custom file name

### DIFF
--- a/lib/src/updater.dart
+++ b/lib/src/updater.dart
@@ -95,13 +95,20 @@ class UpdateResult {
       var dir = Platform.isAndroid
           ? await getExternalStorageDirectory()
           : await getTemporaryDirectory();
-      var urlContent = downloadUrl.split('/');
-      if (urlContent.isEmpty) {
-        throw Exception("The download URL may be invalid.");
+      var urlContent = Uri.parse(downloadUrl);
+      if (urlContent.queryParameters.containsKey('filname')) {
+        var fileName = urlContent.queryParameters['filname'];
+        var filePath = '${dir!.path}/$fileName';
+        return initDownload(filePath);
+      } else {
+        var urlConten = downloadUrl.split('/');
+        if (urlConten.isEmpty) {
+          throw Exception("The download URL may be invalid.");
+        }
+        // Split a URL and retrieve the file name
+        var filePath = '${dir!.path}/${urlConten[urlConten.length - 1]}';
+        return initDownload(filePath);
       }
-      // Split a URL and retrieve the file name
-      var filePath = '${dir!.path}/${urlContent[urlContent.length - 1]}';
-      return initDownload(filePath);
     } else {
       throw Exception('Platform not supported');
     }


### PR DESCRIPTION
If the url is something like this https://example.com/file?export=download&id=gyuggyu7378687yh, the filename will be incorrect To set your own filename, you need to add the filname=correct_file_name parameter to the url

https://example.com/file?export=download&id=gyuggyu7378687yh&filname=myfile.msix